### PR TITLE
Update Telegraf Config

### DIFF
--- a/telegraf/telegraf.conf
+++ b/telegraf/telegraf.conf
@@ -135,9 +135,20 @@
   #servers = ["tcp://telegraf_mqtt_mosquitto_1:1883"]
   servers = ["tcp://broker.hivemq.com:1883"]
   ## Topics that will be subscribed to.
-  # topics = ["emergency_generator/#"]
-  topics = ["#"]
+  topics = ["emergency_generator/#"]
   qos = 2
   ## Connection timeout for initial connection in seconds
   connection_timeout = "30s"
   data_format = "json_v2"
+    [[inputs.mqtt_consumer.json_v2]]
+        measurement_name = "emergency_generators"
+        [[inputs.mqtt_consumer.json_v2.tag]]
+            path = "generatorID"
+        [[inputs.mqtt_consumer.json_v2.field]]
+            path = "temperature"
+        [[inputs.mqtt_consumer.json_v2.field]]
+            path = "fuel"
+        [[inputs.mqtt_consumer.json_v2.field]]
+            path = "load"
+        [[inputs.mqtt_consumer.json_v2.field]]
+            path = "power"

--- a/telegraf/telegraf.conf
+++ b/telegraf/telegraf.conf
@@ -111,7 +111,7 @@
   ## urls will be written to each interval.
   ##   ex: urls = ["https://us-west-2-1.aws.cloud2.influxdata.com"]
   #urls = ["http://influxdb:8086"]
-  urls = ["$INFLUX_HOST"]
+  urls = ["$INFLUX_URL"]
   ## Token for authentication.
   token = "$INFLUX_TOKEN"
 
@@ -133,7 +133,7 @@
   ##            servers = ["ssl://localhost:1883"]
   ##            servers = ["ws://localhost:1883"]
   #servers = ["tcp://telegraf_mqtt_mosquitto_1:1883"]
-  servers = ["broker.hivemq.com"]
+  servers = ["tcp://broker.hivemq.com:1883"]
   ## Topics that will be subscribed to.
   # topics = ["emergency_generator/#"]
   topics = ["#"]
@@ -141,10 +141,3 @@
   ## Connection timeout for initial connection in seconds
   connection_timeout = "30s"
   data_format = "json_v2"
-
-
-
-
-
-
-

--- a/telegraf/telegraf.conf
+++ b/telegraf/telegraf.conf
@@ -111,12 +111,12 @@
   ## urls will be written to each interval.
   ##   ex: urls = ["https://us-west-2-1.aws.cloud2.influxdata.com"]
   #urls = ["http://influxdb:8086"]
-  urls = ["http://influxdb:8086"]
+  urls = ["$INFLUX_HOST"]
   ## Token for authentication.
-  token = "<INSERT_TOKEN>"
+  token = "$INFLUX_TOKEN"
 
   ## Organization is the name of the organization you wish to write to.
-  organization = "influxroadshow"
+  organization = "$INFLUX_ORG"
 
   ## Destination bucket to write into.
   bucket = "generators"
@@ -133,7 +133,7 @@
   ##            servers = ["ssl://localhost:1883"]
   ##            servers = ["ws://localhost:1883"]
   #servers = ["tcp://telegraf_mqtt_mosquitto_1:1883"]
-  servers = ["tcp://mosquitto:1883"]
+  servers = ["broker.hivemq.com"]
   ## Topics that will be subscribed to.
   # topics = ["emergency_generator/#"]
   topics = ["#"]


### PR DESCRIPTION
- Output plugin: replace org details with environment variables so this config can be used more generally (not sure if you're using this specifically for a demo roadshow account and want it hardcoded)
- Input plugin: updated server URL and added JSON_v2 parsing
  - We were able to get a cloud instance of this simulator and it's pumping into the public MQTT broker so 